### PR TITLE
Remove .gitignore file from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
Not a big deal, but `.gitignore` file is present in dist package fetched from packagist.