### PR TITLE
Mark callback in CacheInterface::get as immediately invoked

### DIFF
--- a/CacheInterface.php
+++ b/CacheInterface.php
@@ -40,6 +40,8 @@ interface CacheInterface
      *                              See https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration
      * @param array      &$metadata The metadata of the cached item {@see ItemInterface::getMetadata()}
      *
+     * @param-immediately-invoked-callable $callback
+     *
      * @return T
      *
      * @throws InvalidArgumentException When $key is not valid or when $beta is negative


### PR DESCRIPTION
This is a [new feature](https://twitter.com/OndrejMirtes/status/1770376144438575258) of PHPStan ([docs](https://phpstan.org/writing-php-code/phpdocs-basics#callables)) which allows proper propagation of [checked exceptions](https://phpstan.org/blog/bring-your-exceptions-under-control) from immediately called callables.